### PR TITLE
feat: implementar botones C y ⌫ con su funcionalidad correspondiente

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -87,6 +87,10 @@ class CalculatorGUI:
                 cmd = lambda t=txt: self.operation_click(t)
             elif txt == '=':
                 cmd = self.equals_click
+            elif txt == 'C':
+                cmd = self.clear_click
+            elif txt == '⌫':
+                cmd = self.backspace_click
             else:
                 cmd = None  # Por ahora, otros botones sin funcionalidad
             
@@ -212,8 +216,41 @@ class CalculatorGUI:
 
 
     def clear_click(self):
-        """Exhibición de Limpia"""
-        pass
+        """Limpia completamente el display y resetea el estado de la calculadora.
+    
+    Resetea:
+        - current_value: cadena vacía
+        - operator: None
+        - first_number: None
+        - Display: vacío
+    
+    Examples:
+        >>> # Display muestra: "235"
+        >>> # Usuario presiona C
+        >>> # Display muestra: ""
+    """
+        self.current_value = ""
+        self.operator = None
+        self.first_number = None
+        self.display.delete(0, tk.END)
+
+
+    def backspace_click(self):
+        """Elimina el último carácter del display.
+        
+        Si el display está vacío, no hace nada.
+        
+        Examples:
+            >>> # Display muestra: "1234"
+            >>> # Usuario presiona ⌫
+            >>> # Display muestra: "123"
+            >>> # Usuario presiona ⌫ tres veces más
+            >>> # Display muestra: ""
+        """
+        if self.current_value:
+            self.current_value = self.current_value[:-1]
+            self.display.delete(0, tk.END)
+            self.display.insert(0, self.current_value)
 
 
 


### PR DESCRIPTION
## 📋 Descripción

Se agregó la funcionalidad de los botones **C (borrar display)** y **⌫ (borrar un caracter)** en la calculadora GUI desarrollada con Tkinter.  
Ahora el usuario puede:

- Limpiar completamente el display y reiniciar el estado de la calculadora.
- Borrar el último carácter ingresado (similar al retroceso de un teclado).

Estos cambios mejoran la experiencia de uso y permiten corregir entradas sin reiniciar toda la operación.

---

## 🔗 Issue Relacionado

Closes #28 

---

## 🎯 Tipo de Cambio

- [x] ✨ Nueva funcionalidad  
- [ ] 🐛 Bug fix  
- [ ] 📝 Mejora de documentación  
- [ ] ♻️ Refactoring  
- [ ] 🧪 Tests  
- [ ] 🎨 Estilo  
- [ ] 🚀 Release  

---

## 🧪 ¿Cómo se ha probado?

- [x] Prueba manual  
- [ ] Tests unitarios  
- [ ] Probado en diferentes sistemas operativos  

**Pasos realizados:**

1. Ejecutar la aplicación con `python gui.py`.
2. Ingresar números y verificar:
   - Que la tecla **C** borre todo correctamente.
   - Que la tecla **⌫** elimine únicamente el último carácter.
3. Probar el funcionamiento durante operaciones matemáticas.

---

## 📝 Código Modificado

Los métodos agregados o corregidos son:

- `clear_click()`  
- `backspace_click()`  
- Conexión de los botones C y ⌫ en `create_widgets()`  
- Corrección del `def backspace_click(self):` (estaba mal indentado fuera de la clase).

---

## ✅ Checklist

- [x] Mi código sigue las convenciones del proyecto  
- [x] He realizado self-review de mi código  
- [x] He agregado comentarios en áreas necesarias  
- [x] He actualizado la documentación correspondiente  
- [x] Mis cambios no generan nuevas advertencias  
- [ ] He agregado tests (si aplica)  
- [x] Los commits siguen Conventional Commits  

---

## 📝 Notas Adicionales

- Se eliminó la importación innecesaria `from tkinter import ttk` (no se usa en el archivo).
- Se corrigió el error `AttributeError: 'CalculatorGUI' object has no attribute 'backspace_click'`  
  causado porque el método estaba mal indentado fuera de la clase.

---

## 👥 Revisores Sugeridos

@Jhos3ph @Jandres25 

