### PR TITLE
fix: evitar resultados complejos para raíces pares negativas

### DIFF
--- a/src/calculator.py
+++ b/src/calculator.py
@@ -105,6 +105,13 @@ def power(base: float, exponent: float) -> float:
         >>> power(5, 0)
         1
     """
+    
+    if base < 0 and exponent != 0:
+        inv_exp = 1 / exponent
+        if abs(inv_exp - round(inv_exp)) < 1e-10:
+            if round(inv_exp) % 2 == 0:
+                raise ValueError("Raíz negativa")
+
     return base ** exponent
 
 def valor_maximo(a: float, b: float) -> float:

--- a/src/gui.py
+++ b/src/gui.py
@@ -331,6 +331,7 @@ class CalculatorGUI:
             >>> # Con paréntesis: (2+3)*4
             >>> # expression = "(2+3)*4"
         """
+        # Si estamos en modo expresión (con paréntesis)
         if self.use_expression_mode:
             self.expression += operation
             self.display.delete(0, tk.END)
@@ -462,9 +463,13 @@ class CalculatorGUI:
                 self.first_number = None
                 self.operator = None
                 
-            except ValueError:
-                self.show_error("Entrada inválida")
+            except ValueError as e:
+                if str(e) == "Raíz negativa":
+                    self.show_error("Raíz negativa")
+                else:
+                    self.show_error("Entrada inválida")
                 return
+            
             except ZeroDivisionError:
                 self.show_error("No se puede dividir por 0")
                 return

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -53,7 +53,8 @@ def test_power():
     assert power(-2, 3) == -8
     assert power(-2, 0) == 1
     assert power(-2, -3) == -0.125
-    # assert power(-4, 0.5) == -2.0, "Error: la raíz cuadrada de un número negativo no es real"
+    with pytest.raises(ValueError, match="Raíz negativa"):
+        power(-4, 0.5)
 
 
 def test_valor_maximo():


### PR DESCRIPTION
## 📋 Descripción

Se solucionó el problema donde el cálculo de raíces pares de números negativos (ej: `√-2`) devolvía números complejos (ej: `1.41j`), lo cual no es el comportamiento deseado para esta calculadora.

Cambios específicos:
- Se agregó validación en [src/calculator.py](cci:7://file:///c:/Users/User/OneDrive/Documentos/ProyectoGrupal%231_teamJ/team-practice/src/calculator.py:0:0-0:0) para lanzar un `ValueError` con el mensaje "Raíz negativa" cuando se intenta una operación de este tipo.
- Se actualizó [src/gui.py](cci:7://file:///c:/Users/User/OneDrive/Documentos/ProyectoGrupal%231_teamJ/team-practice/src/gui.py:0:0-0:0) para capturar este error específico y mostrar el mensaje "⚠️ Raíz negativa" en la pantalla.
- Se agregaron pruebas unitarias para verificar que la excepción se lanza correctamente.

---

## 🔗 Issue Relacionado

Related to #50

---

## 🎯 Tipo de Cambio

- [x] 🐛 Bug fix (corrección de error)
- [ ] ✨ Nueva funcionalidad
- [ ] 📝 Mejora de documentación
- [ ] ♻️ Refactoring (sin cambios de funcionalidad)
- [x] 🧪 Tests (agregar o mejorar tests)
- [ ] 🎨 Estilo (formateo, nombres de variables)
- [ ] 🚀 Release (preparación para release)

---

## 🧪 ¿Cómo se ha probado?

Se realizaron pruebas unitarias y manuales para asegurar que el error se captura y se muestra correctamente.

- [x] Tests unitarios
- [x] Prueba manual
- [ ] Probado en diferentes sistemas operativos

**Comandos ejecutados:**

```bash
pytest tests/test_calculator.py
pytest tests/test_gui.py
python src/gui.py # Para prueba manual
```

---

## ✅ Checklist

<!-- Marca con X lo completado -->

- [x] Mi código sigue las convenciones del proyecto
- [x] He realizado self-review de mi código
- [x] He comentado mi código en áreas complejas
- [ ] He actualizado la documentación correspondiente
- [x] Mis cambios no generan nuevas advertencias
- [x] He agregado tests que prueban mis cambios
- [x] Los tests nuevos y existentes pasan localmente
- [x] Los commits siguen Conventional Commits

---

## 📝 Notas Adicionales

La validación comprueba si el inverso del exponente es un número par (ej: exponente 0.5 -> inverso 2 -> par) para determinar si es una raíz par.

---

## 👥 Revisores Sugeridos

@Jandres25  @alexricardotapiacarita-ai 
